### PR TITLE
feat: firewalld support for Linux over D-BUS

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -26,6 +26,7 @@ require (
 	github.com/docker/docker-credential-helpers v0.9.3 // indirect
 	github.com/fsnotify/fsnotify v1.9.0 // indirect
 	github.com/go-viper/mapstructure/v2 v2.4.0 // indirect
+	github.com/godbus/dbus/v5 v5.2.2 // indirect
 	github.com/google/btree v1.1.2 // indirect
 	github.com/google/go-cmp v0.7.0 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -24,6 +24,8 @@ github.com/fxamacker/cbor/v2 v2.7.0 h1:iM5WgngdRBanHcxugY4JySA0nk1wZorNOpTgCMedv
 github.com/fxamacker/cbor/v2 v2.7.0/go.mod h1:pxXPTn3joSm21Gbwsv0w9OSA2y1HFR9qXEeXQVeNoDQ=
 github.com/go-viper/mapstructure/v2 v2.4.0 h1:EBsztssimR/CONLSZZ04E8qAkxNYq4Qp9LvH92wZUgs=
 github.com/go-viper/mapstructure/v2 v2.4.0/go.mod h1:oJDH3BJKyqBA2TXFhDsKDGDTlndYOZ6rGS0BRZIxGhM=
+github.com/godbus/dbus/v5 v5.2.2 h1:TUR3TgtSVDmjiXOgAAyaZbYmIeP3DPkld3jgKGV8mXQ=
+github.com/godbus/dbus/v5 v5.2.2/go.mod h1:3AAv2+hPq5rdnr5txxxRwiGjPXamgoIHgz9FPBfOp3c=
 github.com/google/btree v1.1.2 h1:xf4v41cLI2Z6FxbKm+8Bu+m8ifhj15JuZ9sa0jZCMUU=
 github.com/google/btree v1.1.2/go.mod h1:qOPhT0dTNdNzV6Z/lhRX0YXUafgPLFUh+gZMl761Gm4=
 github.com/google/go-cmp v0.7.0 h1:wk8382ETsv4JYUZwIsn6YpYiWiBsYLSJiTsyBybVuN8=

--- a/pkg/net/firewalld_linux.go
+++ b/pkg/net/firewalld_linux.go
@@ -1,0 +1,62 @@
+//go:build linux
+
+package net
+
+import (
+	"fmt"
+
+	"github.com/godbus/dbus/v5"
+)
+
+const (
+	firewalldDBusName      = "org.fedoraproject.FirewallD1"
+	firewalldDBusPath      = "/org/fedoraproject/FirewallD1"
+	firewalldDBusInterface = "org.fedoraproject.FirewallD1.zone"
+)
+
+// isFirewalldRunning checks if firewalld is active by looking for its name on
+// the system D-Bus.
+func isFirewalldRunning() bool {
+	conn, err := dbus.SystemBus()
+	if err != nil {
+		return false
+	}
+
+	var names []string
+	if err := conn.BusObject().Call("org.freedesktop.DBus.ListNames", 0).Store(&names); err != nil {
+		return false
+	}
+	for _, name := range names {
+		if name == firewalldDBusName {
+			return true
+		}
+	}
+	return false
+}
+
+// addInterfaceToTrustedZone adds a network interface to firewalld's trusted
+// zone via D-Bus. This ensures that forwarded traffic through the interface is
+// not rejected by firewalld's filter_FORWARD chain, which rejects packets from
+// interfaces not assigned to any zone.
+func addInterfaceToTrustedZone(iface string) error {
+	conn, err := dbus.SystemBus()
+	if err != nil {
+		return fmt.Errorf("connect to system bus: %w", err)
+	}
+
+	obj := conn.Object(firewalldDBusName, firewalldDBusPath)
+	call := obj.Call(firewalldDBusInterface+".addInterface", 0, "trusted", iface)
+	return call.Err
+}
+
+// removeInterfaceFromTrustedZone removes a network interface from firewalld's
+// trusted zone via D-Bus.
+func removeInterfaceFromTrustedZone(iface string) {
+	conn, err := dbus.SystemBus()
+	if err != nil {
+		return
+	}
+
+	obj := conn.Object(firewalldDBusName, firewalldDBusPath)
+	obj.Call(firewalldDBusInterface+".removeInterface", 0, "trusted", iface)
+}


### PR DESCRIPTION
I could not get matchlock to work with firewalld, all traffic automatically got dropped as all new network interfaces get assigned to the "default" zone.

I had Claude write this code to set it up over D-BUS. This avoids any issues that could result from the way different linux distro's install firewalld. But it does add another dependency. The alternative would be to call `firewall-cmd` directly at the risk of more easy breakage.