### PR TITLE
add non-secret environment variable support

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+* Added non-secret environment variable support across CLI and SDKs ([#34](https://github.com/jingkaihe/matchlock/issues/34)): `matchlock run -e/--env`, `--env-file`, persisted visibility via `get`/`inspect`, plus Go/Python SDK create-time `env` support.
 * Mount path validation and normalization fixes for [#32](https://github.com/jingkaihe/matchlock/issues/32) and [#33](https://github.com/jingkaihe/matchlock/issues/33) ([#35](https://github.com/jingkaihe/matchlock/pull/35)).
 * VM lifecycle revamp: append-only lifecycle records in SQLite, reconciliation flow, and new `gc`/`inspect` commands.
 * Metadata migration to SQLite for VM state, subnet allocations, and image metadata.

--- a/cmd/matchlock/errors.go
+++ b/cmd/matchlock/errors.go
@@ -51,6 +51,7 @@ var (
 	ErrBuildingRootfs = errors.New("building rootfs")
 	ErrInvalidVolume  = errors.New("invalid volume mount")
 	ErrInvalidSecret  = errors.New("invalid secret")
+	ErrInvalidEnv     = errors.New("invalid environment variable")
 	ErrCreateSandbox  = errors.New("creating sandbox")
 	ErrStartSandbox   = errors.New("starting sandbox")
 	ErrCloseSandbox   = errors.New("closing sandbox")

--- a/pkg/api/env.go
+++ b/pkg/api/env.go
@@ -1,0 +1,114 @@
+package api
+
+import (
+	"bufio"
+	"os"
+	"strings"
+
+	"github.com/jingkaihe/matchlock/internal/errx"
+)
+
+// ParseEnvVar parses an environment variable in Docker-style format:
+// "KEY=VALUE" (inline value) or "KEY" (read from host environment).
+func ParseEnvVar(spec string) (string, string, error) {
+	eqIdx := strings.Index(spec, "=")
+
+	var name, value string
+	if eqIdx == -1 {
+		name = strings.TrimSpace(spec)
+		if err := validateEnvName(name); err != nil {
+			return "", "", err
+		}
+		v, ok := os.LookupEnv(name)
+		if !ok {
+			return "", "", errx.With(ErrEnvVarNotSet, " $%s", name)
+		}
+		value = v
+	} else {
+		name = strings.TrimSpace(spec[:eqIdx])
+		if err := validateEnvName(name); err != nil {
+			return "", "", err
+		}
+		value = spec[eqIdx+1:]
+	}
+
+	return name, value, nil
+}
+
+// ParseEnvFile parses an env file with one variable per line using the same
+// semantics as ParseEnvVar. Blank lines and lines starting with '#' are ignored.
+func ParseEnvFile(path string) (map[string]string, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return nil, errx.Wrap(ErrReadEnvFile, err)
+	}
+	defer f.Close()
+
+	result := make(map[string]string)
+	scanner := bufio.NewScanner(f)
+	scanner.Buffer(make([]byte, 64*1024), 1024*1024)
+
+	lineNo := 0
+	for scanner.Scan() {
+		lineNo++
+		line := strings.TrimSpace(scanner.Text())
+		if line == "" || strings.HasPrefix(line, "#") {
+			continue
+		}
+
+		name, value, err := ParseEnvVar(line)
+		if err != nil {
+			return nil, errx.With(ErrEnvFileLine, " %s:%d: %v", path, lineNo, err)
+		}
+		result[name] = value
+	}
+	if err := scanner.Err(); err != nil {
+		return nil, errx.Wrap(ErrReadEnvFile, err)
+	}
+
+	return result, nil
+}
+
+// ParseEnvs merges env files and explicit env flags into one map.
+// Later values override earlier ones:
+// 1) env files in provided order, then 2) explicit env specs in provided order.
+func ParseEnvs(envSpecs []string, envFiles []string) (map[string]string, error) {
+	if len(envSpecs) == 0 && len(envFiles) == 0 {
+		return nil, nil
+	}
+
+	result := make(map[string]string)
+
+	for _, path := range envFiles {
+		fileEnv, err := ParseEnvFile(path)
+		if err != nil {
+			return nil, err
+		}
+		for k, v := range fileEnv {
+			result[k] = v
+		}
+	}
+
+	for _, spec := range envSpecs {
+		name, value, err := ParseEnvVar(spec)
+		if err != nil {
+			return nil, err
+		}
+		result[name] = value
+	}
+
+	return result, nil
+}
+
+func validateEnvName(name string) error {
+	if name == "" {
+		return ErrEnvNameEmpty
+	}
+	if strings.Contains(name, "=") {
+		return errx.With(ErrEnvNameInvalid, " %q", name)
+	}
+	if strings.ContainsRune(name, 0) {
+		return errx.With(ErrEnvNameInvalid, " %q", name)
+	}
+	return nil
+}

--- a/pkg/api/env_test.go
+++ b/pkg/api/env_test.go
@@ -1,0 +1,110 @@
+package api
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseEnvVarInlineValue(t *testing.T) {
+	name, value, err := ParseEnvVar("FOO=bar")
+	require.NoError(t, err)
+	assert.Equal(t, "FOO", name)
+	assert.Equal(t, "bar", value)
+}
+
+func TestParseEnvVarInlineEmptyValue(t *testing.T) {
+	name, value, err := ParseEnvVar("EMPTY=")
+	require.NoError(t, err)
+	assert.Equal(t, "EMPTY", name)
+	assert.Equal(t, "", value)
+}
+
+func TestParseEnvVarInlineValueWithEquals(t *testing.T) {
+	name, value, err := ParseEnvVar("TOKEN=a=b=c")
+	require.NoError(t, err)
+	assert.Equal(t, "TOKEN", name)
+	assert.Equal(t, "a=b=c", value)
+}
+
+func TestParseEnvVarFromHostEnv(t *testing.T) {
+	t.Setenv("FROM_HOST", "host-value")
+	name, value, err := ParseEnvVar("FROM_HOST")
+	require.NoError(t, err)
+	assert.Equal(t, "FROM_HOST", name)
+	assert.Equal(t, "host-value", value)
+}
+
+func TestParseEnvVarFromHostEnvMissing(t *testing.T) {
+	const key = "MATCHLOCK_TEST_ENV_NOT_SET_123"
+	_ = os.Unsetenv(key)
+
+	_, _, err := ParseEnvVar(key)
+	require.Error(t, err)
+	require.ErrorIs(t, err, ErrEnvVarNotSet)
+}
+
+func TestParseEnvVarEmptyName(t *testing.T) {
+	_, _, err := ParseEnvVar("=value")
+	require.Error(t, err)
+	require.ErrorIs(t, err, ErrEnvNameEmpty)
+}
+
+func TestParseEnvFileParsesLinesAndIgnoresComments(t *testing.T) {
+	t.Setenv("FROM_HOST_FILE", "from-host")
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, "app.env")
+	content := "# comment\n\nFOO=bar\nFROM_HOST_FILE\nQUX=quux\n"
+	require.NoError(t, os.WriteFile(path, []byte(content), 0644))
+
+	env, err := ParseEnvFile(path)
+	require.NoError(t, err)
+
+	assert.Equal(t, "bar", env["FOO"])
+	assert.Equal(t, "from-host", env["FROM_HOST_FILE"])
+	assert.Equal(t, "quux", env["QUX"])
+}
+
+func TestParseEnvFileReturnsLineNumberOnParseError(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "bad.env")
+	require.NoError(t, os.WriteFile(path, []byte("GOOD=1\n=bad\n"), 0644))
+
+	_, err := ParseEnvFile(path)
+	require.Error(t, err)
+	require.ErrorIs(t, err, ErrEnvFileLine)
+	assert.Contains(t, err.Error(), ":2:")
+}
+
+func TestParseEnvsPrecedence(t *testing.T) {
+	t.Setenv("HOST_ONLY", "host-value")
+
+	dir := t.TempDir()
+	file1 := filepath.Join(dir, "one.env")
+	file2 := filepath.Join(dir, "two.env")
+
+	require.NoError(t, os.WriteFile(file1, []byte("A=1\nB=from-file1\n"), 0644))
+	require.NoError(t, os.WriteFile(file2, []byte("B=from-file2\nC=3\n"), 0644))
+
+	env, err := ParseEnvs(
+		[]string{"C=from-flag", "D=4", "HOST_ONLY"},
+		[]string{file1, file2},
+	)
+	require.NoError(t, err)
+
+	assert.Equal(t, "1", env["A"])
+	assert.Equal(t, "from-file2", env["B"])
+	assert.Equal(t, "from-flag", env["C"])
+	assert.Equal(t, "4", env["D"])
+	assert.Equal(t, "host-value", env["HOST_ONLY"])
+}
+
+func TestParseEnvsNoInputReturnsNil(t *testing.T) {
+	env, err := ParseEnvs(nil, nil)
+	require.NoError(t, err)
+	assert.Nil(t, env)
+}

--- a/pkg/api/errors.go
+++ b/pkg/api/errors.go
@@ -17,4 +17,10 @@ var (
 	ErrUnknownMountOption  = errors.New("unknown option")
 	ErrGuestPathNotAbs     = errors.New("guest path must be absolute")
 	ErrGuestPathOutside    = errors.New("guest path must be within workspace")
+
+	ErrEnvNameEmpty   = errors.New("environment variable name cannot be empty")
+	ErrEnvNameInvalid = errors.New("environment variable name is invalid")
+	ErrEnvVarNotSet   = errors.New("environment variable is not set")
+	ErrReadEnvFile    = errors.New("read env file")
+	ErrEnvFileLine    = errors.New("parse env file line")
 )

--- a/pkg/sandbox/sandbox_common.go
+++ b/pkg/sandbox/sandbox_common.go
@@ -59,6 +59,9 @@ func prepareExecEnv(config *api.Config, caPool *sandboxnet.CAPool, pol *policy.E
 			opts.User = ic.User
 		}
 	}
+	for k, v := range config.Env {
+		opts.Env[k] = v
+	}
 
 	if caPool != nil {
 		certPath := "/etc/ssl/certs/matchlock-ca.crt"

--- a/pkg/sandbox/sandbox_common_test.go
+++ b/pkg/sandbox/sandbox_common_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/jingkaihe/matchlock/pkg/api"
+	"github.com/jingkaihe/matchlock/pkg/policy"
 	"github.com/jingkaihe/matchlock/pkg/vfs"
 	"github.com/stretchr/testify/require"
 )
@@ -64,4 +65,43 @@ func TestBuildVFSProvidersDoesNotDuplicateCanonicalWorkspaceMount(t *testing.T) 
 	}
 
 	require.Equal(t, 1, workspaceMounts, "expected exactly one canonical workspace mount (providers=%d)", len(providers))
+}
+
+func TestPrepareExecEnv_ConfigEnvOverridesImageEnv(t *testing.T) {
+	config := &api.Config{
+		VFS: &api.VFSConfig{Workspace: "/workspace"},
+		ImageCfg: &api.ImageConfig{
+			Env: map[string]string{
+				"FOO": "from-image",
+				"BAR": "from-image",
+			},
+		},
+		Env: map[string]string{
+			"FOO": "from-config",
+		},
+	}
+
+	opts := prepareExecEnv(config, nil, nil)
+	require.Equal(t, "from-config", opts.Env["FOO"])
+	require.Equal(t, "from-image", opts.Env["BAR"])
+}
+
+func TestPrepareExecEnv_SecretPlaceholderOverridesConfigEnv(t *testing.T) {
+	config := &api.Config{
+		VFS: &api.VFSConfig{Workspace: "/workspace"},
+		Env: map[string]string{
+			"API_KEY": "not-secret",
+		},
+	}
+	pol := policy.NewEngine(&api.NetworkConfig{
+		Secrets: map[string]api.Secret{
+			"API_KEY": {Value: "real-secret"},
+		},
+	})
+
+	opts := prepareExecEnv(config, nil, pol)
+
+	require.NotEmpty(t, opts.Env["API_KEY"])
+	require.NotEqual(t, "not-secret", opts.Env["API_KEY"])
+	require.Contains(t, opts.Env["API_KEY"], "SANDBOX_SECRET_")
 }

--- a/pkg/sdk/builder.go
+++ b/pkg/sdk/builder.go
@@ -59,6 +59,26 @@ func (b *SandboxBuilder) WithWorkspace(path string) *SandboxBuilder {
 	return b
 }
 
+// WithEnv sets a non-secret environment variable available to commands.
+func (b *SandboxBuilder) WithEnv(name, value string) *SandboxBuilder {
+	if b.opts.Env == nil {
+		b.opts.Env = make(map[string]string)
+	}
+	b.opts.Env[name] = value
+	return b
+}
+
+// WithEnvMap merges non-secret environment variables into the sandbox config.
+func (b *SandboxBuilder) WithEnvMap(env map[string]string) *SandboxBuilder {
+	if b.opts.Env == nil {
+		b.opts.Env = make(map[string]string)
+	}
+	for k, v := range env {
+		b.opts.Env[k] = v
+	}
+	return b
+}
+
 // AllowHost adds one or more hosts to the network allowlist (supports glob patterns).
 func (b *SandboxBuilder) AllowHost(hosts ...string) *SandboxBuilder {
 	b.opts.AllowedHosts = append(b.opts.AllowedHosts, hosts...)

--- a/pkg/sdk/builder_test.go
+++ b/pkg/sdk/builder_test.go
@@ -67,6 +67,31 @@ func TestBuilderWorkspace(t *testing.T) {
 	require.Equal(t, "/home/user/code", opts.Workspace)
 }
 
+func TestBuilderEnv(t *testing.T) {
+	opts := New("alpine:latest").
+		WithEnv("FOO", "bar").
+		WithEnv("HELLO", "world").
+		Options()
+
+	require.Equal(t, map[string]string{
+		"FOO":   "bar",
+		"HELLO": "world",
+	}, opts.Env)
+}
+
+func TestBuilderEnvMapMerge(t *testing.T) {
+	opts := New("alpine:latest").
+		WithEnv("FOO", "old").
+		WithEnvMap(map[string]string{
+			"FOO": "new",
+			"BAR": "baz",
+		}).
+		Options()
+
+	require.Equal(t, "new", opts.Env["FOO"])
+	require.Equal(t, "baz", opts.Env["BAR"])
+}
+
 func TestBuilderDNSServers(t *testing.T) {
 	opts := New("alpine:latest").
 		WithDNSServers("1.1.1.1", "1.0.0.1").
@@ -121,6 +146,7 @@ func TestBuilderFullChain(t *testing.T) {
 	opts := New("python:3.12-alpine").
 		WithCPUs(2).
 		WithMemory(1024).
+		WithEnv("PLAIN_TOKEN", "abc123").
 		AllowHost("dl-cdn.alpinelinux.org", "api.anthropic.com").
 		AddSecret("ANTHROPIC_API_KEY", "sk-ant-xxx", "api.anthropic.com").
 		BlockPrivateIPs().
@@ -134,6 +160,7 @@ func TestBuilderFullChain(t *testing.T) {
 	require.Equal(t, 1024, opts.MemoryMB)
 	require.Len(t, opts.AllowedHosts, 2)
 	require.Len(t, opts.Secrets, 1)
+	require.Equal(t, "abc123", opts.Env["PLAIN_TOKEN"])
 	require.True(t, opts.BlockPrivateIPs)
 	require.Equal(t, "/code", opts.Workspace)
 	require.Len(t, opts.Mounts, 1)

--- a/pkg/sdk/client.go
+++ b/pkg/sdk/client.go
@@ -200,6 +200,9 @@ type CreateOptions struct {
 	BlockPrivateIPs bool
 	// Mounts defines VFS mount configurations
 	Mounts map[string]MountConfig
+	// Env defines non-secret environment variables for command execution.
+	// These are visible in VM state and inspect/get outputs.
+	Env map[string]string
 	// Secrets defines secrets to inject (replaced in HTTP requests to allowed hosts)
 	Secrets []Secret
 	// Workspace is the mount point for VFS in the guest (default: /workspace)
@@ -299,6 +302,10 @@ func (c *Client) Create(opts CreateOptions) (string, error) {
 			vfs["workspace"] = opts.Workspace
 		}
 		params["vfs"] = vfs
+	}
+
+	if len(opts.Env) > 0 {
+		params["env"] = opts.Env
 	}
 
 	if opts.ImageConfig != nil {

--- a/sdk/python/matchlock/builder.py
+++ b/sdk/python/matchlock/builder.py
@@ -39,6 +39,14 @@ class Sandbox:
         self._opts.workspace = path
         return self
 
+    def with_env(self, name: str, value: str) -> Sandbox:
+        self._opts.env[name] = value
+        return self
+
+    def with_env_map(self, env: dict[str, str]) -> Sandbox:
+        self._opts.env.update(env)
+        return self
+
     def allow_host(self, *hosts: str) -> Sandbox:
         self._opts.allowed_hosts.extend(hosts)
         return self

--- a/sdk/python/matchlock/client.py
+++ b/sdk/python/matchlock/client.py
@@ -350,6 +350,9 @@ class Client:
                 vfs["workspace"] = opts.workspace
             params["vfs"] = vfs
 
+        if opts.env:
+            params["env"] = opts.env
+
         if opts.image_config is not None:
             params["image_config"] = opts.image_config.to_dict()
 

--- a/sdk/python/matchlock/types.py
+++ b/sdk/python/matchlock/types.py
@@ -118,6 +118,9 @@ class CreateOptions:
     mounts: dict[str, MountConfig] = field(default_factory=dict)
     """VFS mount configurations keyed by guest path."""
 
+    env: dict[str, str] = field(default_factory=dict)
+    """Non-secret environment variables available to commands."""
+
     secrets: list[Secret] = field(default_factory=list)
     """Secrets to inject (replaced in HTTP requests to allowed hosts)."""
 

--- a/sdk/python/tests/test_builder.py
+++ b/sdk/python/tests/test_builder.py
@@ -62,6 +62,8 @@ class TestSandboxChaining:
         assert isinstance(s.with_disk_size(1), Sandbox)
         assert isinstance(s.with_timeout(1), Sandbox)
         assert isinstance(s.with_workspace("/x"), Sandbox)
+        assert isinstance(s.with_env("K", "V"), Sandbox)
+        assert isinstance(s.with_env_map({"K": "V"}), Sandbox)
         assert isinstance(s.allow_host("x.com"), Sandbox)
         assert isinstance(s.block_private_ips(), Sandbox)
         assert isinstance(s.add_secret("k", "v"), Sandbox)
@@ -74,6 +76,19 @@ class TestSandboxChaining:
 
 
 class TestSandboxNetwork:
+    def test_env_single(self):
+        opts = Sandbox("img").with_env("FOO", "bar").options()
+        assert opts.env == {"FOO": "bar"}
+
+    def test_env_map_merge(self):
+        opts = (
+            Sandbox("img")
+            .with_env("A", "1")
+            .with_env_map({"A": "2", "B": "3"})
+            .options()
+        )
+        assert opts.env == {"A": "2", "B": "3"}
+
     def test_allow_host_single(self):
         opts = Sandbox("img").allow_host("api.example.com").options()
         assert opts.allowed_hosts == ["api.example.com"]

--- a/sdk/python/tests/test_client.py
+++ b/sdk/python/tests/test_client.py
@@ -251,6 +251,32 @@ class TestClientCreate:
         finally:
             fake.close_stdout()
 
+    def test_create_with_env(self):
+        client, fake = make_client_with_fake()
+        try:
+            def respond():
+                import time
+                time.sleep(0.05)
+                fake.push_response({
+                    "jsonrpc": "2.0",
+                    "id": 1,
+                    "result": {"id": "vm-env"},
+                })
+
+            t = threading.Thread(target=respond, daemon=True)
+            t.start()
+            opts = CreateOptions(image="img", env={"FOO": "bar", "BAR": "baz"})
+            vm_id = client.create(opts)
+            assert vm_id == "vm-env"
+
+            req_line = fake.stdin.getvalue().strip().splitlines()[0]
+            req = json.loads(req_line)
+            assert req["method"] == "create"
+            assert req["params"]["env"] == {"FOO": "bar", "BAR": "baz"}
+            t.join(timeout=2)
+        finally:
+            fake.close_stdout()
+
     def test_create_rpc_error(self):
         client, fake = make_client_with_fake()
         try:

--- a/sdk/python/tests/test_types.py
+++ b/sdk/python/tests/test_types.py
@@ -78,6 +78,7 @@ class TestCreateOptions:
         assert opts.allowed_hosts == []
         assert opts.block_private_ips is False
         assert opts.mounts == {}
+        assert opts.env == {}
         assert opts.secrets == []
         assert opts.workspace == ""
 
@@ -90,6 +91,9 @@ class TestCreateOptions:
         b = CreateOptions()
         a.allowed_hosts.append("x.com")
         assert b.allowed_hosts == []
+
+        a.env["FOO"] = "bar"
+        assert b.env == {}
 
         a.secrets.append(Secret(name="K", value="V"))
         assert b.secrets == []

--- a/tests/acceptance/cli_vm_lifecycle_test.go
+++ b/tests/acceptance/cli_vm_lifecycle_test.go
@@ -18,7 +18,7 @@ func TestCLILifecycle(t *testing.T) {
 	bin := matchlockBin(t)
 
 	// Start a sandbox with --rm=false (it stays alive)
-	cmd := exec.Command(bin, "run", "--image", "alpine:latest", "--rm=false")
+	cmd := exec.Command(bin, "run", "--image", "alpine:latest", "--rm=false", "-e", "VISIBLE_ENV=from-run")
 	var runStderr strings.Builder
 	cmd.Stderr = &runStderr
 	require.NoError(t, cmd.Start(), "failed to start run")
@@ -79,6 +79,12 @@ func TestCLILifecycle(t *testing.T) {
 		require.NoErrorf(t, err, "get output is not valid JSON: %s", stdout)
 		assert.Equal(t, vmID, state["id"])
 		assert.Equal(t, "running", state["status"])
+
+		cfg, ok := state["config"].(map[string]interface{})
+		require.True(t, ok, "state.config should be an object")
+		env, ok := cfg["env"].(map[string]interface{})
+		require.True(t, ok, "state.config.env should be an object")
+		assert.Equal(t, "from-run", env["VISIBLE_ENV"])
 	})
 
 	// --- inspect ---
@@ -97,6 +103,12 @@ func TestCLILifecycle(t *testing.T) {
 		assert.Equal(t, vmID, out.VM["id"])
 		assert.Equal(t, vmID, out.Lifecycle["vm_id"])
 		assert.NotEmpty(t, out.History)
+
+		cfg, ok := out.VM["config"].(map[string]interface{})
+		require.True(t, ok, "vm.config should be an object")
+		env, ok := cfg["env"].(map[string]interface{})
+		require.True(t, ok, "vm.config.env should be an object")
+		assert.Equal(t, "from-run", env["VISIBLE_ENV"])
 	})
 
 	// --- stat (alias of inspect) ---

--- a/tests/acceptance/sdk_exec_test.go
+++ b/tests/acceptance/sdk_exec_test.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/jingkaihe/matchlock/pkg/sdk"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -133,6 +134,15 @@ func TestGuestEnvironment(t *testing.T) {
 	result, err := client.Exec(context.Background(), "cat /etc/os-release")
 	require.NoError(t, err, "Exec")
 	assert.Contains(t, result.Stdout, "Alpine")
+}
+
+func TestGuestEnvironmentFromBuilderEnv(t *testing.T) {
+	t.Parallel()
+	client := launchWithBuilder(t, sdk.New("alpine:latest").WithEnv("PLAIN_ENV", "from-builder"))
+
+	result, err := client.Exec(context.Background(), `sh -c 'printf "%s" "$PLAIN_ENV"'`)
+	require.NoError(t, err, "Exec")
+	assert.Equal(t, "from-builder", strings.TrimSpace(result.Stdout))
 }
 
 func TestLargeOutput(t *testing.T) {


### PR DESCRIPTION
Issue: https://github.com/jingkaihe/matchlock/issues/34

Examples:

```bash
./bin/matchlock run -it --rm --image ubuntu:24.04 -e FOO=BAR -e ALICE=BOB --
echo echo root@matchlock:/workspace# echo $FOO
BAR
root@matchlock:/workspace# echo $ALICE
BOB
root@matchlock:/workspace#
exit


$ cat > dotenv <<EOF
> FOO=BAR
> ALICE=BOB
> EOF
$ ./bin/matchlock run -it --rm --image ubuntu:24.04 --env-file dotfile -- 'echo $FOO $BAR'
invalid environment variable: read env file: open dotfile: no such file or directory
$ ./bin/matchlock run -it --rm --image ubuntu:24.04 --env-file dotenv --
root@matchlock:/workspace# echo $ALICE
BOB
root@matchlock:/workspace# echo $FOO
BAR
```