### PR TITLE
Support mounting host directories outside workspace

### DIFF
--- a/cmd/matchlock/cmd_run.go
+++ b/cmd/matchlock/cmd_run.go
@@ -101,6 +101,7 @@ func init() {
 	runCmd.Flags().StringSlice("allow-host", nil, "Allowed hosts (can be repeated)")
 	runCmd.Flags().StringSlice("add-host", nil, "Add a custom host-to-IP mapping (host:ip, can be repeated)")
 	runCmd.Flags().StringSliceP("volume", "v", nil, fmt.Sprintf("Volume mount (host:guest = overlay snapshot by default; use :%s for direct rw host mount, :%s for read-only host mount)", api.MountTypeHostFS, api.MountOptionReadonlyShort))
+	runCmd.Flags().StringSlice("direct-mount", nil, "Mount host directory at arbitrary guest path (host:guest[:rw], read-only by default)")
 	runCmd.Flags().StringSlice("disk", nil, "Attach raw ext4 disk image (host_path:guest_mount[:ro] or @volume_name:guest_mount[:ro])")
 	runCmd.Flags().StringArrayP("env", "e", nil, "Environment variable (KEY=VALUE or KEY; can be repeated)")
 	runCmd.Flags().StringArray("env-file", nil, "Environment file (KEY=VALUE or KEY per line; can be repeated)")
@@ -133,6 +134,7 @@ func init() {
 	viper.BindPFlag("run.allow-host", runCmd.Flags().Lookup("allow-host"))
 	viper.BindPFlag("run.add-host", runCmd.Flags().Lookup("add-host"))
 	viper.BindPFlag("run.volume", runCmd.Flags().Lookup("volume"))
+	viper.BindPFlag("run.direct-mount", runCmd.Flags().Lookup("direct-mount"))
 	viper.BindPFlag("run.disk", runCmd.Flags().Lookup("disk"))
 	viper.BindPFlag("run.env", runCmd.Flags().Lookup("env"))
 	viper.BindPFlag("run.env-file", runCmd.Flags().Lookup("env-file"))
@@ -190,6 +192,7 @@ func runRun(cmd *cobra.Command, args []string) error {
 	// Network & security
 	allowHosts, _ := cmd.Flags().GetStringSlice("allow-host")
 	addHostSpecs, _ := cmd.Flags().GetStringSlice("add-host")
+	directMountSpecs, _ := cmd.Flags().GetStringSlice("direct-mount")
 	volumes, _ := cmd.Flags().GetStringSlice("volume")
 	diskMountSpecs, _ := cmd.Flags().GetStringSlice("disk")
 	envVars, _ := cmd.Flags().GetStringArray("env")
@@ -310,8 +313,22 @@ func runRun(cmd *cobra.Command, args []string) error {
 	}
 
 	var vfsConfig *api.VFSConfig
-	if workspaceSet || len(volumes) > 0 {
+	if workspaceSet || len(volumes) > 0 || len(directMountSpecs) > 0 {
 		vfsConfig = &api.VFSConfig{Workspace: workspace}
+	}
+	if len(directMountSpecs) > 0 {
+		directMounts := make(map[string]api.DirectMount)
+		for _, spec := range directMountSpecs {
+			dm, err := api.ParseDirectMountSpec(spec)
+			if err != nil {
+				return errx.With(ErrInvalidVolume, " --direct-mount %q: %w", spec, err)
+			}
+			directMounts[dm.GuestPath] = api.DirectMount{
+				HostPath: dm.HostPath,
+				Readonly: dm.Readonly,
+			}
+		}
+		vfsConfig.DirectMounts = directMounts
 	}
 	if len(volumes) > 0 {
 		if workspace == "" {
@@ -334,7 +351,7 @@ func runRun(cmd *cobra.Command, args []string) error {
 		vfsConfig.Mounts = mounts
 	}
 
-	hasVFSMounts := vfsConfig != nil && len(vfsConfig.Mounts) > 0
+	hasVFSMounts := vfsConfig != nil && (len(vfsConfig.Mounts) > 0 || len(vfsConfig.DirectMounts) > 0)
 	extraDisks := make([]api.DiskMount, 0, len(diskMountSpecs))
 	for _, spec := range diskMountSpecs {
 		diskMount, err := parseDiskMountSpec(spec)

--- a/internal/guestruntime/fused/main.go
+++ b/internal/guestruntime/fused/main.go
@@ -82,6 +82,8 @@ type VFSStat struct {
 	ModTime int64  `cbor:"mtime"`
 	IsDir   bool   `cbor:"is_dir"`
 	Ino     uint64 `cbor:"ino,omitempty"`
+	UID     uint32 `cbor:"uid,omitempty"`
+	GID     uint32 `cbor:"gid,omitempty"`
 }
 
 type VFSDirEntry struct {
@@ -654,6 +656,8 @@ func fillAttr(attr *fuse.Attr, stat *VFSStat) {
 	attr.Blksize = 4096
 	attr.Blocks = (uint64(stat.Size) + 511) / 512
 	attr.Ino = stat.Ino
+	attr.Uid = stat.UID
+	attr.Gid = stat.GID
 	if stat.IsDir {
 		attr.Mode = syscall.S_IFDIR | (stat.Mode & 0777)
 		attr.Nlink = 2
@@ -782,75 +786,124 @@ func getWorkspaceFromCmdline() string {
 	return ""
 }
 
-func Run() {
-	// Get workspace from kernel cmdline.
-	mountpoint := getWorkspaceFromCmdline()
-	if len(os.Args) > 1 {
-		mountpoint = os.Args[1]
+func getDirectMountsFromCmdline() []string {
+	data, err := os.ReadFile("/proc/cmdline")
+	if err != nil {
+		return nil
 	}
-	if mountpoint == "" {
-		fmt.Fprintln(os.Stderr, "Missing workspace mountpoint")
-		os.Exit(1)
+	for _, part := range strings.Fields(string(data)) {
+		if strings.HasPrefix(part, "matchlock.direct_mount=") {
+			val := strings.TrimPrefix(part, "matchlock.direct_mount=")
+			if val == "" {
+				return nil
+			}
+			return strings.Split(val, ",")
+		}
 	}
+	return nil
+}
 
-	fmt.Printf("Guest FUSE daemon (go-fuse) starting, mounting at %s...\n", mountpoint)
-
-	if err := os.MkdirAll(mountpoint, 0755); err != nil {
-		fmt.Fprintf(os.Stderr, "Failed to create mountpoint: %v\n", err)
-		os.Exit(1)
-	}
-
-	// Connect to host VFS server with retries
+func connectVFSClient() (*VFSClient, error) {
 	var client *VFSClient
 	var err error
 	for i := 0; i < 30; i++ {
 		client, err = NewVFSClient()
 		if err == nil {
-			break
+			return client, nil
 		}
 		time.Sleep(100 * time.Millisecond)
 	}
-	if err != nil {
-		fmt.Fprintf(os.Stderr, "Failed to connect to VFS server: %v\n", err)
-		os.Exit(1)
+	return nil, err
+}
+
+func Run() {
+	// Collect mount points from kernel cmdline and args.
+	workspace := getWorkspaceFromCmdline()
+	if len(os.Args) > 1 {
+		workspace = os.Args[1]
 	}
-	defer client.Close()
-	fmt.Println("Connected to VFS server")
+	directMounts := getDirectMountsFromCmdline()
 
-	// Create root node - basePath must match the VFS mount configuration on host
-	root := &VFSRoot{client: client, basePath: mountpoint}
-
-	// Mount with go-fuse using DirectMountStrict to avoid fusermount dependency
-	opts := &fs.Options{
-		MountOptions: fuse.MountOptions{
-			AllowOther:        true,
-			FsName:            "matchlock",
-			Name:              "fuse.matchlock",
-			Debug:             false,
-			DirectMountStrict: true,
-		},
-		AttrTimeout:  &[]time.Duration{time.Second}[0],
-		EntryTimeout: &[]time.Duration{time.Second}[0],
+	var mountpoints []string
+	if workspace != "" {
+		mountpoints = append(mountpoints, workspace)
 	}
+	mountpoints = append(mountpoints, directMounts...)
 
-	server, err := fs.Mount(mountpoint, root, opts)
-	if err != nil {
-		fmt.Fprintf(os.Stderr, "Failed to mount: %v\n", err)
+	if len(mountpoints) == 0 {
+		fmt.Fprintln(os.Stderr, "No mount points configured (no workspace or direct mounts)")
 		os.Exit(1)
 	}
 
-	fmt.Printf("FUSE filesystem mounted at %s\n", mountpoint)
+	fmt.Printf("Guest FUSE daemon (go-fuse) starting, %d mount point(s)...\n", len(mountpoints))
 
-	// Handle signals for graceful shutdown
+	// Create all mountpoint directories.
+	for _, mp := range mountpoints {
+		if err := os.MkdirAll(mp, 0755); err != nil {
+			fmt.Fprintf(os.Stderr, "Failed to create mountpoint %s: %v\n", mp, err)
+			os.Exit(1)
+		}
+	}
+
+	// Mount each point with its own VFSClient and FUSE server.
+	var servers []*fuse.Server
+	var clients []*VFSClient
+
+	for _, mp := range mountpoints {
+		client, err := connectVFSClient()
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Failed to connect to VFS server for %s: %v\n", mp, err)
+			os.Exit(1)
+		}
+		clients = append(clients, client)
+		fmt.Printf("Connected to VFS server for %s\n", mp)
+
+		root := &VFSRoot{client: client, basePath: mp}
+		opts := &fs.Options{
+			MountOptions: fuse.MountOptions{
+				AllowOther:        true,
+				FsName:            "matchlock",
+				Name:              "fuse.matchlock",
+				Debug:             false,
+				DirectMountStrict: true,
+			},
+			AttrTimeout:  &[]time.Duration{time.Second}[0],
+			EntryTimeout: &[]time.Duration{time.Second}[0],
+		}
+
+		server, err := fs.Mount(mp, root, opts)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Failed to mount %s: %v\n", mp, err)
+			os.Exit(1)
+		}
+		servers = append(servers, server)
+		fmt.Printf("FUSE filesystem mounted at %s\n", mp)
+	}
+
+	// Handle signals for graceful shutdown.
 	sigCh := make(chan os.Signal, 1)
 	signal.Notify(sigCh, syscall.SIGINT, syscall.SIGTERM)
 
 	go func() {
 		<-sigCh
 		fmt.Println("Shutting down...")
-		server.Unmount()
+		for _, s := range servers {
+			s.Unmount()
+		}
 	}()
 
-	// Serve until unmounted
-	server.Wait()
+	// Wait for all servers.
+	var wg sync.WaitGroup
+	for _, s := range servers {
+		wg.Add(1)
+		go func(srv *fuse.Server) {
+			defer wg.Done()
+			srv.Wait()
+		}(s)
+	}
+	wg.Wait()
+
+	for _, c := range clients {
+		c.Close()
+	}
 }

--- a/pkg/api/config.go
+++ b/pkg/api/config.go
@@ -200,7 +200,7 @@ func (c *Config) GetWorkspace() string {
 
 // HasVFSMounts reports whether VFS is enabled with at least one mount.
 func (c *Config) HasVFSMounts() bool {
-	return c != nil && c.VFS != nil && len(c.VFS.Mounts) > 0
+	return c != nil && c.VFS != nil && (len(c.VFS.Mounts) > 0 || len(c.VFS.DirectMounts) > 0)
 }
 
 // ValidateVFS checks VFS config invariants.
@@ -208,9 +208,10 @@ func (c *Config) HasVFSMounts() bool {
 // Rules:
 // - vfs.workspace requires at least one vfs.mounts entry
 // - vfs.mounts requires a non-empty vfs.workspace
-// - vfs.interception requires at least one vfs.mounts entry
+// - vfs.interception requires at least one vfs.mounts entry (workspace-based or direct)
 // - vfs.workspace must be a safe absolute guest path
 // - every vfs.mounts key must be under vfs.workspace
+// - direct_mounts do not require a workspace and guest paths must be safe absolute paths
 func (c *Config) ValidateVFS() error {
 	if c == nil || c.VFS == nil {
 		return nil
@@ -219,6 +220,7 @@ func (c *Config) ValidateVFS() error {
 	workspace := c.VFS.Workspace
 	hasWorkspace := strings.TrimSpace(workspace) != ""
 	hasMounts := len(c.VFS.Mounts) > 0
+	hasDirectMounts := len(c.VFS.DirectMounts) > 0
 	hasInterception := c.VFS.Interception != nil
 
 	if hasWorkspace && !hasMounts {
@@ -227,9 +229,17 @@ func (c *Config) ValidateVFS() error {
 	if hasMounts && !hasWorkspace {
 		return errx.With(ErrInvalidConfig, ": vfs.workspace is required when vfs.mounts is set")
 	}
-	if hasInterception && !hasMounts {
+	if hasInterception && !hasMounts && !hasDirectMounts {
 		return errx.With(ErrInvalidConfig, ": vfs.interception requires at least one vfs.mounts entry")
 	}
+
+	// Validate direct mount guest paths
+	for guestPath := range c.VFS.DirectMounts {
+		if err := ValidateGuestMount(guestPath); err != nil {
+			return errx.With(ErrInvalidConfig, ": vfs.direct_mounts: %v", err)
+		}
+	}
+
 	if !hasMounts {
 		return nil
 	}

--- a/pkg/api/config_test.go
+++ b/pkg/api/config_test.go
@@ -255,3 +255,59 @@ func TestValidateVFS_AllowsInterceptionWithMounts(t *testing.T) {
 
 	require.NoError(t, cfg.ValidateVFS())
 }
+
+func TestValidateVFS_AllowsDirectMountsWithoutWorkspace(t *testing.T) {
+	cfg := &Config{
+		VFS: &VFSConfig{
+			DirectMounts: map[string]DirectMount{
+				"/home/agent/.ssh": {HostPath: "/tmp", Readonly: true},
+			},
+		},
+	}
+
+	require.NoError(t, cfg.ValidateVFS())
+	assert.True(t, cfg.HasVFSMounts())
+}
+
+func TestValidateVFS_AllowsMixedMountsAndDirectMounts(t *testing.T) {
+	cfg := &Config{
+		VFS: &VFSConfig{
+			Workspace: "/workspace",
+			Mounts: map[string]MountConfig{
+				"/workspace/data": {Type: MountTypeMemory},
+			},
+			DirectMounts: map[string]DirectMount{
+				"/home/agent/.ssh": {HostPath: "/tmp", Readonly: true},
+			},
+		},
+	}
+
+	require.NoError(t, cfg.ValidateVFS())
+}
+
+func TestValidateVFS_RejectsInvalidDirectMountPath(t *testing.T) {
+	cfg := &Config{
+		VFS: &VFSConfig{
+			DirectMounts: map[string]DirectMount{
+				"relative/path": {HostPath: "/tmp", Readonly: true},
+			},
+		},
+	}
+
+	err := cfg.ValidateVFS()
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrInvalidConfig)
+	assert.Contains(t, err.Error(), "direct_mounts")
+}
+
+func TestHasVFSMounts_DirectMountsOnly(t *testing.T) {
+	cfg := &Config{
+		VFS: &VFSConfig{
+			DirectMounts: map[string]DirectMount{
+				"/home/agent/.ssh": {HostPath: "/tmp", Readonly: true},
+			},
+		},
+	}
+
+	assert.True(t, cfg.HasVFSMounts())
+}

--- a/pkg/api/errors.go
+++ b/pkg/api/errors.go
@@ -30,4 +30,6 @@ var (
 	ErrAddHostSpecFormat = errors.New("invalid add-host format")
 	ErrAddHostHost       = errors.New("invalid add-host hostname")
 	ErrAddHostIP         = errors.New("invalid add-host ip")
+
+	ErrInvalidDirectMountFormat = errors.New("expected format host:guest or host:guest:rw")
 )

--- a/pkg/api/mount.go
+++ b/pkg/api/mount.go
@@ -126,6 +126,66 @@ func ValidateVFSMountsWithinWorkspace(mounts map[string]MountConfig, workspace s
 	return nil
 }
 
+// DirectMountSpec is a parsed --direct-mount specification.
+type DirectMountSpec struct {
+	HostPath  string
+	GuestPath string
+	Readonly  bool
+}
+
+// ParseDirectMountSpec parses a direct mount string in format:
+// - "host:guest" (read-only by default)
+// - "host:guest:rw" (read-write)
+func ParseDirectMountSpec(spec string) (DirectMountSpec, error) {
+	parts := strings.Split(spec, ":")
+	if len(parts) < 2 || len(parts) > 3 {
+		return DirectMountSpec{}, ErrInvalidDirectMountFormat
+	}
+
+	hostPath := parts[0]
+	guestPath := parts[1]
+
+	// Resolve to absolute path
+	var err error
+	if !filepath.IsAbs(hostPath) {
+		hostPath, err = filepath.Abs(hostPath)
+		if err != nil {
+			return DirectMountSpec{}, errx.Wrap(ErrResolvePath, err)
+		}
+	}
+
+	// Verify host path exists
+	if _, err := os.Stat(hostPath); err != nil {
+		return DirectMountSpec{}, errx.With(ErrHostPathNotExist, ": %s", hostPath)
+	}
+
+	// Guest path must be absolute
+	if !filepath.IsAbs(guestPath) {
+		return DirectMountSpec{}, errx.With(ErrGuestPathNotAbs, ": %q", guestPath)
+	}
+
+	// Validate guest path is safe for kernel cmdline
+	if err := ValidateGuestMount(guestPath); err != nil {
+		return DirectMountSpec{}, err
+	}
+
+	readonly := true
+	if len(parts) == 3 {
+		switch strings.ToLower(strings.TrimSpace(parts[2])) {
+		case "rw":
+			readonly = false
+		default:
+			return DirectMountSpec{}, errx.With(ErrUnknownMountOption, " %q (use 'rw' for read-write, omit for read-only)", parts[2])
+		}
+	}
+
+	return DirectMountSpec{
+		HostPath:  hostPath,
+		GuestPath: filepath.Clean(guestPath),
+		Readonly:  readonly,
+	}, nil
+}
+
 func isWithinWorkspace(path string, workspace string) bool {
 	path = filepath.Clean(path)
 	workspace = filepath.Clean(workspace)

--- a/pkg/api/mount_test.go
+++ b/pkg/api/mount_test.go
@@ -162,3 +162,53 @@ func TestValidateVFSMountsWithinWorkspaceRejectsRelative(t *testing.T) {
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "must be absolute")
 }
+
+func TestParseDirectMountSpecBasicReadonly(t *testing.T) {
+	hostDir := t.TempDir()
+	spec, err := ParseDirectMountSpec(hostDir + ":/home/agent/.ssh")
+	require.NoError(t, err)
+	assert.Equal(t, hostDir, spec.HostPath)
+	assert.Equal(t, "/home/agent/.ssh", spec.GuestPath)
+	assert.True(t, spec.Readonly, "default should be readonly")
+}
+
+func TestParseDirectMountSpecExplicitRW(t *testing.T) {
+	hostDir := t.TempDir()
+	spec, err := ParseDirectMountSpec(hostDir + ":/home/agent/.aws:rw")
+	require.NoError(t, err)
+	assert.Equal(t, hostDir, spec.HostPath)
+	assert.Equal(t, "/home/agent/.aws", spec.GuestPath)
+	assert.False(t, spec.Readonly, "explicit rw should not be readonly")
+}
+
+func TestParseDirectMountSpecHostNotExist(t *testing.T) {
+	_, err := ParseDirectMountSpec("/nonexistent/path:/home/agent/.ssh")
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "does not exist")
+}
+
+func TestParseDirectMountSpecRelativeGuestPath(t *testing.T) {
+	hostDir := t.TempDir()
+	_, err := ParseDirectMountSpec(hostDir + ":relative/path")
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "must be absolute")
+}
+
+func TestParseDirectMountSpecInvalidFormat(t *testing.T) {
+	_, err := ParseDirectMountSpec("only-one-part")
+	require.Error(t, err)
+	require.ErrorIs(t, err, ErrInvalidDirectMountFormat)
+}
+
+func TestParseDirectMountSpecUnknownOption(t *testing.T) {
+	hostDir := t.TempDir()
+	_, err := ParseDirectMountSpec(hostDir + ":/home/agent/.ssh:wat")
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "unknown option")
+}
+
+func TestParseDirectMountSpecTooManyParts(t *testing.T) {
+	_, err := ParseDirectMountSpec("/a:/b:rw:extra")
+	require.Error(t, err)
+	require.ErrorIs(t, err, ErrInvalidDirectMountFormat)
+}

--- a/pkg/sandbox/sandbox_common.go
+++ b/pkg/sandbox/sandbox_common.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"io"
+	"sort"
 	"strings"
 	"time"
 
@@ -24,7 +25,29 @@ func buildVFSProviders(config *api.Config) map[string]vfs.Provider {
 			vfsProviders[path] = provider
 		}
 	}
+	if config.VFS != nil && config.VFS.DirectMounts != nil {
+		for guestPath, dm := range config.VFS.DirectMounts {
+			var p vfs.Provider = vfs.NewRealFSProvider(dm.HostPath)
+			if dm.Readonly {
+				p = vfs.NewReadonlyProvider(p)
+			}
+			vfsProviders[guestPath] = p
+		}
+	}
 	return vfsProviders
+}
+
+// sortedDirectMountPaths returns sorted guest paths from direct mounts config.
+func sortedDirectMountPaths(config *api.Config) []string {
+	if config.VFS == nil || len(config.VFS.DirectMounts) == 0 {
+		return nil
+	}
+	paths := make([]string, 0, len(config.VFS.DirectMounts))
+	for guestPath := range config.VFS.DirectMounts {
+		paths = append(paths, guestPath)
+	}
+	sort.Strings(paths)
+	return paths
 }
 
 func prepareExecEnv(config *api.Config, caPool *sandboxnet.CAPool, pol *policy.Engine) *api.ExecOptions {

--- a/pkg/sandbox/sandbox_darwin.go
+++ b/pkg/sandbox/sandbox_darwin.go
@@ -246,6 +246,7 @@ func New(ctx context.Context, config *api.Config, opts *Options) (sb *Sandbox, r
 		GuestIP:             guestIP,
 		SubnetCIDR:          subnetCIDR,
 		Workspace:           workspace,
+		DirectMountPaths:    sortedDirectMountPaths(config),
 		UseInterception:     needsInterception,
 		Privileged:          config.Privileged,
 		PrebuiltRootfs:      bootstrapRootfsPath,

--- a/pkg/sandbox/sandbox_linux.go
+++ b/pkg/sandbox/sandbox_linux.go
@@ -258,6 +258,7 @@ func New(ctx context.Context, config *api.Config, opts *Options) (sb *Sandbox, r
 		GuestIP:             guestIP,
 		SubnetCIDR:          subnetCIDR,
 		Workspace:           workspace,
+		DirectMountPaths:    sortedDirectMountPaths(config),
 		Privileged:          config.Privileged,
 		ExtraDisks:          extraDisks,
 		DNSServers:          config.Network.GetDNSServers(),

--- a/pkg/sdk/builder.go
+++ b/pkg/sdk/builder.go
@@ -214,6 +214,24 @@ func (b *SandboxBuilder) MountOverlay(guestPath, hostPath string) *SandboxBuilde
 	return b.Mount(guestPath, MountConfig{Type: api.MountTypeOverlay, HostPath: hostPath})
 }
 
+// MountDirect adds an out-of-workspace host directory mount at the given guest path.
+func (b *SandboxBuilder) MountDirect(guestPath, hostPath string) *SandboxBuilder {
+	if b.opts.DirectMounts == nil {
+		b.opts.DirectMounts = make(map[string]DirectMountConfig)
+	}
+	b.opts.DirectMounts[guestPath] = DirectMountConfig{HostPath: hostPath}
+	return b
+}
+
+// MountDirectReadonly adds a read-only out-of-workspace host directory mount.
+func (b *SandboxBuilder) MountDirectReadonly(guestPath, hostPath string) *SandboxBuilder {
+	if b.opts.DirectMounts == nil {
+		b.opts.DirectMounts = make(map[string]DirectMountConfig)
+	}
+	b.opts.DirectMounts[guestPath] = DirectMountConfig{HostPath: hostPath, Readonly: true}
+	return b
+}
+
 // WithUser sets the user to run commands as (uid, uid:gid, or username).
 func (b *SandboxBuilder) WithUser(user string) *SandboxBuilder {
 	if b.opts.ImageConfig == nil {

--- a/pkg/sdk/create.go
+++ b/pkg/sdk/create.go
@@ -91,10 +91,13 @@ func (c *Client) Create(opts CreateOptions) (string, error) {
 		params["network"] = network
 	}
 
-	if len(opts.Mounts) > 0 || opts.Workspace != "" || wireVFS != nil {
+	if len(opts.Mounts) > 0 || len(opts.DirectMounts) > 0 || opts.Workspace != "" || wireVFS != nil {
 		vfs := make(map[string]interface{})
 		if len(opts.Mounts) > 0 {
 			vfs["mounts"] = opts.Mounts
+		}
+		if len(opts.DirectMounts) > 0 {
+			vfs["direct_mounts"] = opts.DirectMounts
 		}
 		if opts.Workspace != "" {
 			vfs["workspace"] = opts.Workspace

--- a/pkg/sdk/types.go
+++ b/pkg/sdk/types.go
@@ -38,6 +38,9 @@ type CreateOptions struct {
 	NetworkInterception *NetworkInterceptionConfig
 	// Mounts defines VFS mount configurations
 	Mounts map[string]MountConfig
+	// DirectMounts defines out-of-workspace direct host-to-guest mounts.
+	// Key is the guest mount path, value configures the host path and access mode.
+	DirectMounts map[string]DirectMountConfig
 	// Env defines non-secret environment variables for command execution.
 	// These are visible in VM state and inspect/get outputs.
 	Env map[string]string
@@ -195,6 +198,12 @@ type NetworkInterceptionConfig struct {
 type MountConfig struct {
 	Type     string `json:"type"` // memory, host_fs, overlay
 	HostPath string `json:"host_path,omitempty"`
+	Readonly bool   `json:"readonly,omitempty"`
+}
+
+// DirectMountConfig defines an out-of-workspace host-to-guest mount.
+type DirectMountConfig struct {
+	HostPath string `json:"host_path"`
 	Readonly bool   `json:"readonly,omitempty"`
 }
 

--- a/pkg/vfs/server.go
+++ b/pkg/vfs/server.go
@@ -67,6 +67,8 @@ type VFSStat struct {
 	ModTime int64  `cbor:"mtime"`
 	IsDir   bool   `cbor:"is_dir"`
 	Ino     uint64 `cbor:"ino,omitempty"`
+	UID     uint32 `cbor:"uid,omitempty"`
+	GID     uint32 `cbor:"gid,omitempty"`
 }
 
 type VFSDirEntry struct {
@@ -291,13 +293,18 @@ func errnoFromError(err error) int32 {
 }
 
 func statFromInfo(path string, info FileInfo) *VFSStat {
-	return &VFSStat{
+	st := &VFSStat{
 		Size:    info.Size(),
 		Mode:    uint32(info.Mode()),
 		ModTime: info.ModTime().Unix(),
 		IsDir:   info.IsDir(),
 		Ino:     inodeFromFileInfo(path, info, info.IsDir()),
 	}
+	if sysInfo, ok := info.Sys().(*syscall.Stat_t); ok {
+		st.UID = sysInfo.Uid
+		st.GID = sysInfo.Gid
+	}
+	return st
 }
 
 func direntsFromEntries(parentPath string, entries []DirEntry) []VFSDirEntry {

--- a/pkg/vm/backend.go
+++ b/pkg/vm/backend.go
@@ -38,6 +38,7 @@ type VMConfig struct {
 	GuestIP             string              // Guest IP (e.g., 192.168.100.2)
 	SubnetCIDR          string              // CIDR notation (e.g., 192.168.100.1/24)
 	Workspace           string              // Guest VFS mount point (empty when VFS is disabled)
+	DirectMountPaths    []string            // Guest paths for direct mounts (independent of workspace)
 	UseInterception     bool                // Use network interception (MITM proxy)
 	Privileged          bool                // Skip in-guest security restrictions (seccomp, cap drop, no_new_privs)
 	DNSServers          []string            // DNS servers for the guest (default: 8.8.8.8, 8.8.4.4)

--- a/pkg/vm/darwin/backend.go
+++ b/pkg/vm/darwin/backend.go
@@ -206,6 +206,10 @@ func (b *DarwinBackend) buildKernelArgs(config *vm.VMConfig) string {
 	if workspace != "" {
 		workspaceArg = " matchlock.workspace=" + workspace
 	}
+	directMountArg := ""
+	if len(config.DirectMountPaths) > 0 {
+		directMountArg = " matchlock.direct_mount=" + strings.Join(config.DirectMountPaths, ",")
+	}
 
 	hostname := config.Hostname
 	if hostname == "" {
@@ -260,8 +264,8 @@ func (b *DarwinBackend) buildKernelArgs(config *vm.VMConfig) string {
 
 	if config.NoNetwork {
 		return fmt.Sprintf(
-			"console=hvc0 root=/dev/vda rw init=/init reboot=k panic=1 ip=off hostname=%s%s matchlock.dns=%s matchlock.no_network=1%s%s matchlock.cpus=%g",
-			hostname, workspaceArg, vm.KernelDNSParam(config.DNSServers), privilegedArg, diskArgs+addHostArgs, config.CPUs,
+			"console=hvc0 root=/dev/vda rw init=/init reboot=k panic=1 ip=off hostname=%s%s%s matchlock.dns=%s matchlock.no_network=1%s%s matchlock.cpus=%g",
+			hostname, workspaceArg, directMountArg, vm.KernelDNSParam(config.DNSServers), privilegedArg, diskArgs+addHostArgs, config.CPUs,
 		)
 	}
 
@@ -275,14 +279,14 @@ func (b *DarwinBackend) buildKernelArgs(config *vm.VMConfig) string {
 			gatewayIP = "192.168.100.1"
 		}
 		return fmt.Sprintf(
-			"console=hvc0 root=/dev/vda rw init=/init reboot=k panic=1 ip=%s::%s:255.255.255.0::eth0:off%s hostname=%s%s matchlock.dns=%s matchlock.mtu=%d%s%s%s matchlock.cpus=%g",
-			guestIP, gatewayIP, vm.KernelIPDNSSuffix(config.DNSServers), hostname, workspaceArg, vm.KernelDNSParam(config.DNSServers), mtu, privilegedArg, diskArgs, addHostArgs, config.CPUs,
+			"console=hvc0 root=/dev/vda rw init=/init reboot=k panic=1 ip=%s::%s:255.255.255.0::eth0:off%s hostname=%s%s%s matchlock.dns=%s matchlock.mtu=%d%s%s%s matchlock.cpus=%g",
+			guestIP, gatewayIP, vm.KernelIPDNSSuffix(config.DNSServers), hostname, workspaceArg, directMountArg, vm.KernelDNSParam(config.DNSServers), mtu, privilegedArg, diskArgs, addHostArgs, config.CPUs,
 		)
 	}
 
 	return fmt.Sprintf(
-		"console=hvc0 root=/dev/vda rw init=/init reboot=k panic=1 ip=dhcp hostname=%s%s matchlock.dns=%s matchlock.mtu=%d%s%s%s matchlock.cpus=%g",
-		hostname, workspaceArg, vm.KernelDNSParam(config.DNSServers), mtu, privilegedArg, diskArgs, addHostArgs, config.CPUs,
+		"console=hvc0 root=/dev/vda rw init=/init reboot=k panic=1 ip=dhcp hostname=%s%s%s matchlock.dns=%s matchlock.mtu=%d%s%s%s matchlock.cpus=%g",
+		hostname, workspaceArg, directMountArg, vm.KernelDNSParam(config.DNSServers), mtu, privilegedArg, diskArgs, addHostArgs, config.CPUs,
 	)
 }
 

--- a/pkg/vm/linux/backend.go
+++ b/pkg/vm/linux/backend.go
@@ -283,9 +283,13 @@ func (m *LinuxMachine) generateFirecrackerConfig() []byte {
 		if workspace != "" {
 			workspaceArg = " matchlock.workspace=" + workspace
 		}
+		directMountArg := ""
+		if len(m.config.DirectMountPaths) > 0 {
+			directMountArg = " matchlock.direct_mount=" + strings.Join(m.config.DirectMountPaths, ",")
+		}
 
-		kernelArgs = fmt.Sprintf("console=ttyS0 reboot=k panic=1 acpi=off init=/init hostname=%s%s matchlock.dns=%s",
-			hostname, workspaceArg, vm.KernelDNSParam(m.config.DNSServers))
+		kernelArgs = fmt.Sprintf("console=ttyS0 reboot=k panic=1 acpi=off init=/init hostname=%s%s%s matchlock.dns=%s",
+			hostname, workspaceArg, directMountArg, vm.KernelDNSParam(m.config.DNSServers))
 		if m.config.NoNetwork {
 			kernelArgs += " ip=off matchlock.no_network=1"
 		} else {


### PR DESCRIPTION
## Summary

This is a PR for [#82](https://github.com/jingkaihe/matchlock/issues/82).

Add `--direct-mount` flag to mount host directories at arbitrary guest paths, independent of `--workspace`. Also fix FUSE-mounted file ownership to reflect host UID/GID instead of always showing `root:root`.

## Motivation

All VFS mounts currently must be subpaths of `--workspace`. This makes it impossible to mount host credentials or config at locations tools expect them (e.g., `~/.ssh`, `~/.aws`, `~/.config/gh`) without setting up a workspace that encompasses them. Direct mounts solve this by allowing workspace-independent host-to-guest directory mapping.

## Usage

```bash
matchlock run --image myimage \
  --direct-mount ~/.ssh:/home/agent/.ssh \
  --direct-mount ~/.aws:/home/agent/.aws:rw \
  -v "$(pwd)":"$(pwd)":host_fs --workspace "$(pwd)" \
  -- bash -l
```

- Read-only by default, append `:rw` for read-write
- Works with or without `--workspace` — direct-mount-only sandboxes are valid

## Changes

### API layer (`pkg/api/`)
- **`mount.go`**: `DirectMountSpec` type and `ParseDirectMountSpec()` parser — handles `host:guest[:rw]` format with host path validation, guest path safety checks, and absolute path resolution
- **`errors.go`**: `ErrInvalidDirectMountFormat` sentinel error
- **`config.go`**: `HasVFSMounts()` now considers direct mounts; `ValidateVFS()` validates direct mount guest paths independently of workspace; interception check accepts direct mounts
- **`mount_test.go`**: 7 tests for `ParseDirectMountSpec` (basic readonly, explicit rw, host not exist, relative guest, invalid format, unknown option, too many parts)
- **`config_test.go`**: 4 tests (direct mounts without workspace, mixed mounts, invalid path rejection, `HasVFSMounts` with direct mounts only)

### CLI (`cmd/matchlock/`)
- **`cmd_run.go`**: `--direct-mount` repeatable flag, viper binding, parsing into `vfsConfig.DirectMounts` — VFS config now created when direct mounts are present even without workspace

### Sandbox (`pkg/sandbox/`)
- **`sandbox_common.go`**: `buildVFSProviders()` creates `RealFSProvider`/`ReadonlyProvider` for each direct mount; new `sortedDirectMountPaths()` helper for deterministic kernel arg ordering
- **`sandbox_linux.go`** / **`sandbox_darwin.go`**: Pass `sortedDirectMountPaths(config)` to `VMConfig`

### VM backends (`pkg/vm/`)
- **`backend.go`**: `DirectMountPaths []string` added to `VMConfig`
- **`linux/backend.go`**: Adds `matchlock.direct_mount=path1,path2` kernel arg
- **`darwin/backend.go`**: Same kernel arg added to all 3 format string variants (no-network, interception, default)

### Guest FUSE daemon (`internal/guestruntime/fused/`)
- **`main.go`**: `getDirectMountsFromCmdline()` parses `matchlock.direct_mount=` kernel arg; `connectVFSClient()` extracted as helper; `Run()` refactored to collect mount points from both workspace and direct mounts, create one VFSClient + FUSE server per mount, and use `sync.WaitGroup` for concurrent serve/shutdown

### SDK (`pkg/sdk/`)
- **`types.go`**: `DirectMountConfig` struct; `DirectMounts` field on `CreateOptions`
- **`builder.go`**: `MountDirect()` and `MountDirectReadonly()` builder methods
- **`create.go`**: Serializes `direct_mounts` in VFS params of create request

### Bug fix: VFS UID/GID propagation (`pkg/vfs/server.go` + `fused/main.go`)
- `VFSStat` wire format now includes `UID`/`GID` fields
- `statFromInfo()` extracts UID/GID from `syscall.Stat_t` on the host side
- Guest FUSE `fillAttr()` passes UID/GID through to the kernel via `fuse.Attr`
- Fixes all FUSE-mounted files showing as `root:root` — affects workspace mounts too, not just direct mounts

##  Notes

- Written with Claude Code with human guidance.
- I manually verified it works, but I was only able to test it on a Linux host.
- Test are passing.
- The current implementation is only able to mount directories. I'm still working on mounting single files.