### PR TITLE
feat(vfs): implement NodeFsyncer for directory fsync

### DIFF
--- a/internal/guestruntime/fused/main.go
+++ b/internal/guestruntime/fused/main.go
@@ -51,6 +51,7 @@ const (
 	OpSymlink
 	OpReadlink
 	OpLink
+	OpFsyncPath
 )
 
 type VFSRequest struct {
@@ -191,6 +192,26 @@ var _ = (fs.NodeUnlinker)((*VFSNode)(nil))
 var _ = (fs.NodeRmdirer)((*VFSNode)(nil))
 var _ = (fs.NodeRenamer)((*VFSNode)(nil))
 var _ = (fs.NodeSetattrer)((*VFSNode)(nil))
+var _ = (fs.NodeFsyncer)((*VFSNode)(nil))
+
+// Fsync handles fsync on the directory inode (e.g. postgres calling
+// fsync(dir_fd) during WAL recovery). File-level fsync usually arrives via
+// VFSFileHandle.Fsync directly; if the kernel routes one through the node
+// with a handle attached, delegate to that. Otherwise issue a path-based
+// fsync RPC so the host actually flushes the file/dir to disk.
+func (n *VFSNode) Fsync(ctx context.Context, f fs.FileHandle, flags uint32) syscall.Errno {
+	if fh, ok := f.(*VFSFileHandle); ok {
+		return fh.Fsync(ctx, flags)
+	}
+	resp, err := n.client.RequestCtx(ctx, &VFSRequest{Op: OpFsyncPath, Path: n.path})
+	if err != nil {
+		return syscall.EIO
+	}
+	if resp.Err != 0 {
+		return syscall.Errno(-resp.Err)
+	}
+	return 0
+}
 
 func (r *VFSRoot) Getattr(ctx context.Context, fh fs.FileHandle, out *fuse.AttrOut) syscall.Errno {
 	resp, err := r.client.RequestCtx(ctx, &VFSRequest{Op: OpGetattr, Path: r.basePath})

--- a/pkg/vfs/fsync_test.go
+++ b/pkg/vfs/fsync_test.go
@@ -1,0 +1,121 @@
+package vfs
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"syscall"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRealFSProvider_Fsync_File(t *testing.T) {
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "file.txt"), []byte("hi"), 0644))
+
+	p := NewRealFSProvider(dir)
+	require.NoError(t, p.Fsync("/file.txt"))
+}
+
+func TestRealFSProvider_Fsync_Directory(t *testing.T) {
+	dir := t.TempDir()
+	p := NewRealFSProvider(dir)
+
+	require.NoError(t, p.Mkdir("/sub", 0755))
+	// Directory fsync is the scenario postgres hits during WAL recovery.
+	// On Linux this opens the dir O_RDONLY and calls fsync(fd), which the
+	// kernel forwards as FSYNCDIR to the FUSE daemon.
+	require.NoError(t, p.Fsync("/sub"))
+}
+
+func TestRealFSProvider_Fsync_Missing(t *testing.T) {
+	p := NewRealFSProvider(t.TempDir())
+	err := p.Fsync("/does-not-exist")
+	require.Error(t, err)
+	assert.True(t, os.IsNotExist(err), "expected ENOENT, got %v", err)
+}
+
+func TestMemoryProvider_Fsync_Noop(t *testing.T) {
+	mp := NewMemoryProvider()
+	mp.Mkdir("/dir", 0755)
+	// Memory provider has no persistence layer to flush; fsync is a no-op
+	// that returns nil. Behaviour parity with RealFS keeps the Provider
+	// interface uniform.
+	require.NoError(t, mp.Fsync("/dir"))
+	require.NoError(t, mp.Fsync("/does-not-exist"))
+}
+
+func TestReadonlyProvider_Fsync_DelegatesToInner(t *testing.T) {
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "file.txt"), []byte(""), 0644))
+
+	p := NewReadonlyProvider(NewRealFSProvider(dir))
+	require.NoError(t, p.Fsync("/file.txt"))
+	require.Error(t, p.Fsync("/missing"))
+}
+
+func TestMountRouter_Fsync_RoutesToOwningMount(t *testing.T) {
+	dirA := t.TempDir()
+	dirB := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(dirA, "in-a"), []byte(""), 0644))
+	require.NoError(t, os.WriteFile(filepath.Join(dirB, "in-b"), []byte(""), 0644))
+
+	router := NewMountRouter(map[string]Provider{
+		"/mnt/a": NewRealFSProvider(dirA),
+		"/mnt/b": NewRealFSProvider(dirB),
+	})
+
+	require.NoError(t, router.Fsync("/mnt/a/in-a"))
+	require.NoError(t, router.Fsync("/mnt/b/in-b"))
+	// Cross-mount path that doesn't exist on the routed provider.
+	require.Error(t, router.Fsync("/mnt/a/in-b"))
+}
+
+type spyFsyncProvider struct {
+	Provider
+	calls []string
+	err   error
+}
+
+func (p *spyFsyncProvider) Fsync(path string) error {
+	p.calls = append(p.calls, path)
+	return p.err
+}
+
+func TestInterceptProvider_Fsync_DelegatesAndPropagatesError(t *testing.T) {
+	want := errors.New("disk gone")
+	spy := &spyFsyncProvider{Provider: NewMemoryProvider(), err: want}
+	p := NewInterceptProvider(spy, NewHookEngine(nil))
+
+	require.ErrorIs(t, p.Fsync("/x"), want)
+	require.Equal(t, []string{"/x"}, spy.calls)
+}
+
+func TestDispatch_OpFsyncPath_File(t *testing.T) {
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "file.txt"), []byte(""), 0644))
+
+	s := NewVFSServer(NewRealFSProvider(dir))
+	resp := s.dispatch(&VFSRequest{Op: OpFsyncPath, Path: "/file.txt"})
+	assert.Equal(t, int32(0), resp.Err)
+}
+
+func TestDispatch_OpFsyncPath_Directory(t *testing.T) {
+	dir := t.TempDir()
+
+	s := NewVFSServer(NewRealFSProvider(dir))
+	require.Equal(t, int32(0), s.dispatch(&VFSRequest{Op: OpMkdir, Path: "/sub", Mode: 0755}).Err)
+
+	resp := s.dispatch(&VFSRequest{Op: OpFsyncPath, Path: "/sub"})
+	assert.Equal(t, int32(0), resp.Err, "directory fsync via OpFsyncPath should succeed (this is the postgres-WAL-recovery scenario)")
+}
+
+func TestDispatch_OpFsyncPath_PropagatesProviderError(t *testing.T) {
+	want := syscall.EIO
+	s := NewVFSServer(&spyFsyncProvider{Provider: NewMemoryProvider(), err: want})
+
+	resp := s.dispatch(&VFSRequest{Op: OpFsyncPath, Path: "/x"})
+	assert.Equal(t, -int32(want), resp.Err)
+}

--- a/pkg/vfs/interceptor.go
+++ b/pkg/vfs/interceptor.go
@@ -186,6 +186,16 @@ func (p *interceptProvider) Readlink(path string) (string, error) {
 	return result, err
 }
 
+func (p *interceptProvider) Fsync(path string) error {
+	req := p.baseRequest(HookOpSync, path)
+	if err := p.hooks.Before(&req); err != nil {
+		return err
+	}
+	err := p.inner.Fsync(req.Path)
+	p.hooks.After(req, HookResult{Err: err})
+	return err
+}
+
 type interceptHandle struct {
 	inner Handle
 	hooks *HookEngine

--- a/pkg/vfs/memory.go
+++ b/pkg/vfs/memory.go
@@ -273,6 +273,8 @@ func (p *MemoryProvider) Readlink(path string) (string, error) {
 	return "", syscall.ENOSYS
 }
 
+func (p *MemoryProvider) Fsync(path string) error { return nil }
+
 type memHandle struct {
 	file   *memFile
 	flags  int

--- a/pkg/vfs/provider.go
+++ b/pkg/vfs/provider.go
@@ -20,6 +20,7 @@ type Provider interface {
 	Rename(oldPath, newPath string) error
 	Symlink(target, link string) error
 	Readlink(path string) (string, error)
+	Fsync(path string) error
 }
 
 type Handle interface {

--- a/pkg/vfs/readonly.go
+++ b/pkg/vfs/readonly.go
@@ -39,6 +39,7 @@ func (p *ReadonlyProvider) RemoveAll(path string) error               { return s
 func (p *ReadonlyProvider) Rename(oldPath, newPath string) error      { return syscall.EROFS }
 func (p *ReadonlyProvider) Symlink(target, link string) error         { return syscall.EROFS }
 func (p *ReadonlyProvider) Readlink(path string) (string, error)      { return p.inner.Readlink(path) }
+func (p *ReadonlyProvider) Fsync(path string) error                   { return p.inner.Fsync(path) }
 
 type readonlyHandle struct {
 	inner Handle

--- a/pkg/vfs/realfs.go
+++ b/pkg/vfs/realfs.go
@@ -122,6 +122,15 @@ func (p *RealFSProvider) Readlink(path string) (string, error) {
 	return os.Readlink(p.realPath(path))
 }
 
+func (p *RealFSProvider) Fsync(path string) error {
+	f, err := os.Open(p.realPath(path))
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+	return f.Sync()
+}
+
 type realHandle struct {
 	file     *os.File
 	ownerUID *uint32

--- a/pkg/vfs/router.go
+++ b/pkg/vfs/router.go
@@ -289,6 +289,14 @@ func (r *MountRouter) Readlink(path string) (string, error) {
 	return p.Readlink(rel)
 }
 
+func (r *MountRouter) Fsync(path string) error {
+	p, rel, err := r.resolve(path)
+	if err != nil {
+		return err
+	}
+	return p.Fsync(rel)
+}
+
 func (r *MountRouter) AddMount(path string, provider Provider) {
 	path = filepath.Clean(path)
 	r.mounts = append(r.mounts, mount{path: path, provider: provider})

--- a/pkg/vfs/server.go
+++ b/pkg/vfs/server.go
@@ -36,6 +36,7 @@ const (
 	OpSymlink
 	OpReadlink
 	OpLink
+	OpFsyncPath
 )
 
 type VFSRequest struct {
@@ -265,6 +266,12 @@ func (s *VFSServer) dispatch(req *VFSRequest) *VFSResponse {
 	case OpFsync:
 		if hi, ok := s.handles.Load(req.Handle); ok {
 			hi.(Handle).Sync()
+		}
+		return &VFSResponse{}
+
+	case OpFsyncPath:
+		if err := provider.Fsync(req.Path); err != nil {
+			return &VFSResponse{Err: errnoFromError(err)}
 		}
 		return &VFSResponse{}
 

--- a/tests/acceptance/cli_fsync_test.go
+++ b/tests/acceptance/cli_fsync_test.go
@@ -1,0 +1,93 @@
+//go:build acceptance
+
+package acceptance
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestCLIRunHostFSDirectoryFsync exercises the FUSE FSYNCDIR opcode end-to-end
+// against a host_fs mount. Without VFSNode.Fsync implemented, the in-VM
+// fsync(2) on a directory file descriptor falls through to go-fuse's default
+// and returns ENOSYS/ENOTSUP — the same failure postgres hits during WAL
+// recovery against a host_fs-mounted PGDATA. With the fix in place, the
+// helper observes a clean fsync and prints FSYNC_OK.
+//
+// We cross-compile a tiny Go helper instead of installing python in the VM
+// so the test stays offline (no apk add) and self-contained.
+func TestCLIRunHostFSDirectoryFsync(t *testing.T) {
+	hostDir := t.TempDir()
+
+	helperSrc := filepath.Join(t.TempDir(), "fsync_helper.go")
+	require.NoError(t, os.WriteFile(helperSrc, []byte(fsyncHelperSource), 0644))
+
+	helperBin := filepath.Join(hostDir, "fsync-helper")
+	build := exec.Command("go", "build", "-o", helperBin, helperSrc)
+	build.Env = append(os.Environ(),
+		"GOOS=linux",
+		"GOARCH="+runtime.GOARCH,
+		"CGO_ENABLED=0",
+	)
+	if out, err := build.CombinedOutput(); err != nil {
+		t.Fatalf("cross-compile helper failed: %v\n%s", err, out)
+	}
+	require.NoError(t, os.Chmod(helperBin, 0755))
+
+	guestCmd := strings.Join([]string{
+		"mkdir -p /workspace/repo/sub",
+		"/workspace/repo/fsync-helper /workspace/repo/sub",
+	}, " && ")
+
+	stdout, stderr, exitCode := runCLIWithTimeout(
+		t,
+		3*time.Minute,
+		"run",
+		"--image", "alpine:latest",
+		"--workspace", "/workspace",
+		"--no-network",
+		"-v", fmt.Sprintf("%s:repo:host_fs", hostDir),
+		"--", "sh", "-c", guestCmd,
+	)
+	require.Equalf(t, 0, exitCode, "fsync helper exited non-zero — VFSNode.Fsync likely returns ENOSYS\nstdout: %s\nstderr: %s", stdout, stderr)
+	assert.Contains(t, stdout, "FSYNC_OK")
+}
+
+// fsyncHelperSource is compiled at test setup and dropped into the host_fs
+// mount, then exec'd from inside the VM. Opens the given path O_RDONLY and
+// calls fsync(2) on the resulting FD — for a directory path that becomes a
+// FUSE FSYNCDIR.
+const fsyncHelperSource = `package main
+
+import (
+	"fmt"
+	"os"
+)
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: fsync-helper <path>")
+		os.Exit(2)
+	}
+	f, err := os.Open(os.Args[1])
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "open %s: %v\n", os.Args[1], err)
+		os.Exit(1)
+	}
+	defer f.Close()
+	if err := f.Sync(); err != nil {
+		fmt.Fprintf(os.Stderr, "fsync %s: %v\n", os.Args[1], err)
+		os.Exit(1)
+	}
+	fmt.Println("FSYNC_OK")
+}
+`


### PR DESCRIPTION
VFSFileHandle in internal/guestruntime/fused/main.go implements fs.FileFsyncer, which handles fsync on an open file FD. VFSNode (the directory inode) does NOT implement fs.NodeFsyncer, so fsync on a directory FD falls through to go-fuse's default and returns ENOSYS / ENOTSUP. PostgreSQL relies on directory fsync during WAL recovery (see recovery_init_sync_method) and PANICs when it fails, so a postgres cluster cannot run against a PGDATA mounted via host_fs. Any application using the standard "write to tmpfile → atomic rename → fsync(parent_dir)" durability recipe hits the same gap.

Provider gains Fsync(path string) error implemented by each provider (real / memory / readonly / router / interceptor). A new OpFsyncPath op is added — appended to the iota list so wire compatibility with older guest-init builds is preserved. fs.NodeFsyncer on VFSNode delegates to VFSFileHandle.Fsync when a handle is attached and otherwise issues OpFsyncPath with the node's path.

Tests:
- pkg/vfs/fsync_test.go: per-provider unit tests plus dispatch tests for OpFsyncPath (file, directory, error propagation).
- tests/acceptance/cli_fsync_test.go: cross-compiles a tiny Go helper that fsync's a directory FD on a host_fs mount inside an alpine VM. Verified to fail against upstream/main with "sync: operation not supported" and pass with this commit.

Co-authored with Opus 4.7