### PR TITLE
go sdk: allow setting user in ExecPipe

### DIFF
--- a/examples/go/exec_modes/main.go
+++ b/examples/go/exec_modes/main.go
@@ -101,7 +101,7 @@ func run() error {
 		}
 	}()
 
-	ttyResult, err := client.ExecInteractive(ctx, "sh", &sdk.ExecInteractiveOptions{
+	ttyResult, err := client.ExecInteractive(ctx, "sh", sdk.ExecInteractiveOptions{
 		WorkingDir: "/workspace",
 		Rows:       uint16(rows),
 		Cols:       uint16(cols),

--- a/pkg/sdk/exec.go
+++ b/pkg/sdk/exec.go
@@ -152,20 +152,28 @@ func (c *Client) ExecStreamWithDir(ctx context.Context, command, workingDir stri
 	}, nil
 }
 
-// ExecPipe executes a command in pipe mode with bidirectional stdin/stdout/stderr.
-// This mode does not allocate a PTY.
-func (c *Client) ExecPipe(ctx context.Context, command string, stdin io.Reader, stdout, stderr io.Writer) (*ExecPipeResult, error) {
-	return c.ExecPipeWithDir(ctx, command, "", stdin, stdout, stderr)
+// Parameters for `ExecPipe`. The zero value of this struct provides defaults.
+type ExecPipeOptions struct {
+	WorkingDir string
+	User       string
+	Stdin      io.Reader
+	Stdout     io.Writer
+	Stderr     io.Writer
 }
 
-// ExecPipeWithDir executes a command in pipe mode with a working directory.
-func (c *Client) ExecPipeWithDir(ctx context.Context, command, workingDir string, stdin io.Reader, stdout, stderr io.Writer) (*ExecPipeResult, error) {
+// ExecPipe executes a command in pipe mode with bidirectional stdin/stdout/stderr.
+// This mode does not allocate a PTY.
+func (c *Client) ExecPipe(ctx context.Context, command string, opts ExecPipeOptions) (*ExecPipeResult, error) {
 	params := map[string]string{
 		"command": command,
 	}
-	if workingDir != "" {
-		params["working_dir"] = workingDir
+	if opts.WorkingDir != "" {
+		params["working_dir"] = opts.WorkingDir
 	}
+	if opts.User != "" {
+		params["user"] = opts.User
+	}
+	stdin, stdout, stderr := opts.Stdin, opts.Stdout, opts.Stderr
 
 	reqID := c.requestID.Add(1)
 	readyCh := make(chan struct{})
@@ -227,11 +235,7 @@ func (c *Client) ExecPipeWithDir(ctx context.Context, command, workingDir string
 }
 
 // ExecInteractive executes a command in TTY mode (equivalent to CLI -it behavior).
-func (c *Client) ExecInteractive(ctx context.Context, command string, opts *ExecInteractiveOptions) (*ExecInteractiveResult, error) {
-	if opts == nil {
-		opts = &ExecInteractiveOptions{}
-	}
-
+func (c *Client) ExecInteractive(ctx context.Context, command string, opts ExecInteractiveOptions) (*ExecInteractiveResult, error) {
 	rows := opts.Rows
 	cols := opts.Cols
 	if rows == 0 {

--- a/pkg/sdk/exec_test.go
+++ b/pkg/sdk/exec_test.go
@@ -62,7 +62,7 @@ func newExecRPCClient(t *testing.T, handle func(inboundRPC, func(interface{}))) 
 	return c, cleanup
 }
 
-func TestExecPipeWithDir(t *testing.T) {
+func TestExecPipe(t *testing.T) {
 	var gotCommand string
 	var gotDir string
 	var gotStdin string
@@ -135,7 +135,7 @@ func TestExecPipeWithDir(t *testing.T) {
 
 	stdin := strings.NewReader("hello-pipe")
 	var stdout, stderr bytes.Buffer
-	result, err := client.ExecPipeWithDir(context.Background(), "cat", "/tmp", stdin, &stdout, &stderr)
+	result, err := client.ExecPipe(context.Background(), "cat", ExecPipeOptions{WorkingDir: "/tmp", Stdin: stdin, Stdout: &stdout, Stderr: &stderr})
 	require.NoError(t, err)
 	require.NotNil(t, result)
 	assert.Equal(t, 5, result.ExitCode)
@@ -251,7 +251,7 @@ func TestExecInteractive(t *testing.T) {
 	close(resize)
 
 	var stdout bytes.Buffer
-	result, err := client.ExecInteractive(context.Background(), "sh", &ExecInteractiveOptions{
+	result, err := client.ExecInteractive(context.Background(), "sh", ExecInteractiveOptions{
 		Rows:   40,
 		Cols:   100,
 		Stdin:  strings.NewReader("tty-input"),


### PR DESCRIPTION
This was necessary for running Claude Code as non-root user in my harness.

Deletes ExecPipeDir for being made redundant.

This also cleans up another function which takes a pointer for no reason: the zero value of the struct is already the same thing as the nil of the pointer, so this is a redundant optionality.

Commentary: I don't know how the vibe is on doing breaking API changes. I could of course retain existing APIs as deprecated. Let me know if you'd rather me do that.

AI disclosure: yep it was written with AI but it looks exactly as I would write it by hand. I fixed the comments; my main thought on this topic is that I am not a gopher so am not an API design witch.